### PR TITLE
Remove unused debounce vars

### DIFF
--- a/esp8266-lock-portal.ino
+++ b/esp8266-lock-portal.ino
@@ -25,9 +25,6 @@ const unsigned long ledPulseDuration = 100;  // ms
 
 #define BUTTON_PIN D2
 const int buttonPin = 4;  // D2
-bool lastButtonState = HIGH;
-unsigned long lastDebounceTime = 0;
-const unsigned long debounceDelay = 50;  // ms
 
 // Página principal
 void handleRoot() {


### PR DESCRIPTION
## Summary
- delete old button debounce state variables

## Testing
- `arduino-builder -compile -hardware /usr/share/arduino/hardware -tools /usr/bin -fqbn arduino:avr:uno esp8266-lock-portal.ino` *(fails: `ESP8266WiFi.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68404f2148a48332b3c9766fab5649a9