### PR TITLE
Fix initial cooldown bug

### DIFF
--- a/esp8266-lock-portal.ino
+++ b/esp8266-lock-portal.ino
@@ -271,6 +271,9 @@ void setup() {
 
   Serial.begin(9600);
 
+  // Allow immediate command execution after boot by resetting the cooldown
+  lastCommandTime = millis() - commandCooldown;
+
   WiFi.softAP(apSSID);
   IPAddress myIP = WiFi.softAPIP();
   Serial.println("AP IP address: ");


### PR DESCRIPTION
## Summary
- allow the first command to execute immediately after boot by adjusting the cooldown timer

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y arduino-cli` *(fails: `Unable to locate package`)*

------
https://chatgpt.com/codex/tasks/task_e_68404e6bd8948332bd79d376c4090b03